### PR TITLE
fix #1: pdf generation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import { inject } from '@vercel/analytics';
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import './App.css';
 import Markdown from 'react-markdown'
@@ -66,22 +66,33 @@ const Form = ({ country, situation, onCountryChange, onSituationChange, onGenera
 
 const Response = ({ response, isResponseAvailable }) => {
   const [pdfGenerating, setPdfGenerating] = useState(false);
+  const pdfResponse = useRef();
 
   const generatePDF = () => {
     setPdfGenerating(true);
 
-    const element = document.createElement("div");
-    element.innerHTML = response;
+    const opt = {
+      margin:       1,
+      image:        { type: 'jpeg', quality: 1 },
+      html2canvas:  { scale: 3 },
+      jsPDF:        { unit: 'in', format: 'letter', orientation: 'portrait' },
+      pagebreak:    { mode: ['avoid-all']}
+    };
 
-    html2pdf().from(element).save('QuineLaw.pdf').then(() => {
+    const element = document.createElement("div");
+    element.innerHTML = pdfResponse.current.innerHTML;
+
+    html2pdf().set(opt).from(element).save('QuineLaw.pdf').then(() => {
       setPdfGenerating(false);
     });
   };
 
   return (
     <div className="container">
-      <h2>QuineLaw says:</h2>
-      <ul><Markdown>{response}</Markdown></ul>
+      <div ref={pdfResponse}>
+        <h2>QuineLaw says:</h2>
+        <ul><Markdown>{response}</Markdown></ul>
+      </div>
       {isResponseAvailable && (
         <button className="download-button" onClick={generatePDF} disabled={pdfGenerating}>
           {pdfGenerating ? "Generating PDF..." : "Download as PDF"}


### PR DESCRIPTION
set opt (i.e. options) for html2pdf (like margin, format, scale, auto page break, etc)

<Markdown> tag will set the html tags according to response
so, I Wrapped h2 and response in a div and used a ref to access that div directly.
Then used ref to set the innerHTML of created element to ref.current.innerHTML
this will preserve the dom generated by <Markdown> and the same will then be used by html2pdf

Feel free to tweak some options in opt as needed 
but this should generate well formatted pdf ( as generated by Markdown)